### PR TITLE
AccidentalTerminationProtection - Added Test to ensure all EC2 Instan…

### DIFF
--- a/aws/api/EC2.py
+++ b/aws/api/EC2.py
@@ -3,6 +3,9 @@ import boto3
 class EC2:
     def __init__(self):
         self.ec2 = boto3.client('ec2')
+        self.ec2_resource = boto3.resource('ec2')
 
     def getSecurityGroups(self):
         return self.ec2.describe_security_groups()
+    def getInstances(self):
+    	return self.ec2_resource.instances

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,7 @@ Networking:
   testSshNotOpenFromInternet: True
   testRdpNotOpenFromInternet: True
   testPortsOpenFromTheInternet: True
+  testApiTerminationIsDisabled: True
 
 Iam:
   testRootAccountLoginIsAvoided: True


### PR DESCRIPTION
Test written and validated by running on a AWS VPC account. Moreover, using **boto3 resource instead of client for EC2**. [Boto3 resource](http://boto3.readthedocs.io/en/latest/guide/resources.html) are just a nice abstraction over service clients. Using resource, I did not have to deal with parsing the response structure.